### PR TITLE
rework crypto.ts

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -41,7 +41,7 @@ These functions have a similar calling signature:
 This is essentially what the main `verify()` function does
 
 ```js
-import { low, Context } from './src/index';
+import { low, Context } from './src/index.js';
 
 // create a new context
 const context = new Context();

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ export default {
     // TypeScript encourages you not to use an extension "import foo from './foo'"
     // If you don't supply an extension in your TS imports, your transpiled JavaScript will give you some form of 'module not found' error at runtime.
     // As a workaround, TypeScript allows you to use a JavaScript extension '.js' in your TypeScript imports and it works fine - so your
-    // transpiled JavaScript will also have the extention as required by NodeJS and browser.
+    // transpiled JavaScript will also have the extension as required by NodeJS and browser.
     // Unfortunately, ts-jest (& ts-node) will give you a 'module not found' error when you do include a JavaScript extension in your TS
     // files.  So, we use this custom resolver to help ts-jest resolve the imports correctly.
     // Apparently, this has been an issue with TS for some time. TS refuses to auto-add the .js extension to its transpiled code claiming that

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@rollup/plugin-babel": "^5.3.0",
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-node-resolve": "^13.1.3",
-        "@rollup/plugin-replace": "^4.0.0",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.13",
         "@types/qrcode": "^1.4.2",
@@ -2495,19 +2494,6 @@
       },
       "peerDependencies": {
         "rollup": "^2.42.0"
-      }
-    },
-    "node_modules/@rollup/plugin-replace": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz",
-      "integrity": "sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/pluginutils": "^3.1.0",
-        "magic-string": "^0.25.7"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0 || ^2.0.0"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -9586,16 +9572,6 @@
         "deepmerge": "^4.2.2",
         "is-module": "^1.0.0",
         "resolve": "^1.19.0"
-      }
-    },
-    "@rollup/plugin-replace": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz",
-      "integrity": "sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^3.1.0",
-        "magic-string": "^0.25.7"
       }
     },
     "@rollup/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-node-resolve": "^13.1.3",
-    "@rollup/plugin-replace": "^4.0.0",
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.13",
     "@types/qrcode": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prepare": "npm run build",
     "build": "npm run clean && npm run tsc && npm run rollup && npm run minify",
     "test": "jest",
-    "tsc": "tsc && rm -rf ./esm/lib && mv ./esm/src/* ./esm/ && rm -r ./esm/src",
+    "tsc": "tsc",
     "tsc:index.d.ts": "tsc -p tsconfig.d.ts.json",
     "rollup": "rollup -c",
     "minify": "uglifyjs ./umd/smart-health-card-decoder.umd.js -c -m --mangle-props keep_quoted -o ./umd/smart-health-card-decoder.umd.min.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,6 @@
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import babel from '@rollup/plugin-babel';
-import replace from '@rollup/plugin-replace';
 import cleanup from "rollup-plugin-cleanup";
 
 

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -13,8 +13,25 @@ declare module "crypto" {
 // So for now, we're just defaulting to the polyfill for all versions of Node.
 // TODO: use Node crypto or webcrypto, when available.
 
-import pollyFillCrypto from '../lib/msrCrypto.cjs';
-const subtle : SubtleCrypto = (typeof crypto === 'undefined' ? pollyFillCrypto : crypto).subtle as SubtleCrypto;
+const nodeCrypto = require('crypto');
+const polyFillCrypto = require('../lib/msrCrypto.cjs');
+const browserCrypto = typeof crypto === 'undefined' ? undefined : crypto;
 
+let subtle = polyFillCrypto?.subtle;
+
+// Node 15+
+if( nodeCrypto?.webcrypto ) {
+  subtle = nodeCrypto.webcrypto.subtle;
+} 
+
+// Node 14
+else if ( nodeCrypto ) {
+  // TODO: wrap node sign/verify
+}
+
+// Browser
+else if ( browserCrypto ) {
+  subtle = crypto.subtle;
+}
 
 export default subtle;

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import convert from "./convert";
-import { JWK } from "./types";
+import convert from "./convert.js";
+import { JWK } from "./types.js";
 
 
 // The lib types for Node does not properly expose the webcrypto api, 

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,37 +1,341 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-// The Node types does not properly expose the webcrypto api, so we have to declare it ourselves to keep TS happy. 
+import convert from "./convert";
+import { JWK } from "./types";
+
+
+// The lib types for Node does not properly expose the webcrypto api, 
+// so we have to declare it ourselves to keep TS happy. 
 declare module "crypto" {
-  namespace webcrypto {
-    const subtle: SubtleCrypto;
-  }
+    namespace webcrypto {
+        const subtle: SubtleCrypto;
+    }
 }
 
-// Uses browser web crypto api when available - defaults to a webcrypto polyfill when it's not
-// Node15+ has a webcrypto api available. For Node14 and earlier, though, it does not
-// So for now, we're just defaulting to the polyfill for all versions of Node.
-// TODO: use Node crypto or webcrypto, when available.
 
-const nodeCrypto = require('crypto');
-const polyFillCrypto = require('../lib/msrCrypto.cjs');
+// Using commonjs type imports to avoid the static imports of esm and the errors it creates when the import is not present
+// Require may or may not exist, so we create a do-nothing function if it's not found.
+const req = (typeof require === 'function') ? require : () => { };
+const nodeCrypto = req('crypto');
 const browserCrypto = typeof crypto === 'undefined' ? undefined : crypto;
 
-let subtle = polyFillCrypto?.subtle;
 
-// Node 15+
-if( nodeCrypto?.webcrypto ) {
-  subtle = nodeCrypto.webcrypto.subtle;
-} 
+let subtle: SubtleCrypto | undefined;
 
-// Node 14
-else if ( nodeCrypto ) {
-  // TODO: wrap node sign/verify
+// Node 15+ : use Node's webcrypto api
+if (nodeCrypto?.webcrypto) {
+    subtle = nodeCrypto.webcrypto.subtle;
 }
 
-// Browser
-else if ( browserCrypto ) {
-  subtle = crypto.subtle;
+// Browser : user built-in webcrypto api
+else if (browserCrypto?.subtle) {
+    subtle = browserCrypto.subtle;
 }
 
-export default subtle;
+// Webcrypto polyfill if we can't find any of the above crypto apis
+// IE11 uses mscrypto.subtle, but it does not have the EC algorithms we need so we polyfill it instead of shimming its webcrypto api
+if (!nodeCrypto && !subtle) {
+    subtle = req('../lib/msrCrypto.cjs')?.subtle;
+}
+
+
+// if nodeCrypto && !subtle, then we are using Node14 (or earlier) crypto
+
+
+function nodeHash(data: BufferSource): Promise<string> {
+    try {
+        return Promise.resolve((nodeCrypto.createHash('sha256').update(data).digest() as Buffer).toString('base64url'));
+    } catch (err) {
+        throw err;
+    }
+}
+
+
+function nodeVerify(publicKey: JWK, signature: Uint8Array, data: Uint8Array): Promise<boolean> {
+
+    try {
+
+        // convert the JWK key to a PEM key
+        const pemKey = jwkToPublicPEM(publicKey as JWK);
+
+        // DER encode the signature
+        const derSig = derSignature(signature);
+
+        // check the signature
+        const result = nodeCrypto.createVerify('SHA256').update(data).end().verify(pemKey, derSig);
+
+        return Promise.resolve(result);
+
+    } catch (err) {
+        throw err;
+    }
+}
+
+
+function nodeSign(privateKey: JWK, data: Uint8Array): Promise<ArrayBuffer> {
+
+    try {
+        // convert the JWK key to a PEM key
+        const pemKey = jwkToPrivatePEM(privateKey as JWK);
+
+        // sign the data
+        const buffer = nodeCrypto.createSign('SHA256').update(data).sign(pemKey);
+
+        // decode the DER encoding into an r||s byte array
+        const nonDer = unDerSignature(buffer);
+
+        return Promise.resolve(nonDer);
+
+    } catch (err) {
+        throw err;
+    }
+}
+
+
+function subtleHash(data: BufferSource): Promise<string> {
+
+    if (!subtle) throw new Error('Could not find crypto object');
+
+    return subtle.digest({ name: "SHA-256", }, data)
+        .then((arrayBuffer: ArrayBuffer) => {
+            const uint8 = new Uint8Array(arrayBuffer);
+            const hash = convert.bytesToBase64(uint8, true);
+            return hash;
+        })
+        .catch((error: Error) => {
+            throw error;
+        });
+
+}
+
+
+function subtleVerify(publicKey: JsonWebKey, signature: Uint8Array, data: Uint8Array): Promise<boolean> {
+
+    if (!subtle) throw new Error('Could not find crypto object');
+
+    return subtle.importKey("jwk", publicKey as JsonWebKey, { name: "ECDSA", namedCurve: "P-256" }, false, ["verify"])
+        .then(cryptoKey => {
+            return (subtle as SubtleCrypto).verify({ name: "ECDSA", hash: { name: "SHA-256" } }, cryptoKey, signature, data);
+        })
+        .then(verified => {
+            return verified;
+        })
+        .catch(err => {
+            throw err;
+        });
+
+}
+
+
+function subtleSign(privateKey: JsonWebKey, data: Uint8Array): Promise<ArrayBuffer> {
+
+    if (!subtle) throw new Error('Could not find crypto object');
+
+    return subtle.importKey("jwk", privateKey as JsonWebKey, { name: "ECDSA", namedCurve: "P-256" }, false, ["sign"])
+        .then(cryptoKey => {
+            return (subtle as SubtleCrypto).sign({ name: "ECDSA", hash: { name: "SHA-256" } }, cryptoKey, data);
+        })
+        .then(signature => {
+            return signature;
+        })
+        .catch(err => {
+            throw err;
+        });
+}
+
+
+function unDerSignature(buffer: ArrayBuffer): ArrayBuffer {
+
+    const bytes = new Uint8Array(buffer);
+
+    // For signature use, the sign is irrelevant and the leading zero, if present, is ignored.
+    const rStart = 4 + (bytes[3] - 32);  // adjust for the potential leading zero
+    const rBytes = bytes.slice(rStart, rStart + 32); // 32 bytes of the r-integer 
+    const sStart = bytes.length - 32; // gets the last 32, so we can ignore any leading zero
+    const sBytes = bytes.slice(sStart); // 32 bytes of the s-integer
+
+    const rs = new Uint8Array([...rBytes, ...sBytes]);
+
+    return rs.buffer;
+}
+
+
+function derSignature(bytes: Uint8Array): Uint8Array {
+
+    let rBytes = bytes.slice(0, 32);
+    let sBytes = bytes.slice(32);
+
+    // if the high-order bit is set, pre-pend a zero to keep the asn.1 Integer as a positive number
+    if (rBytes[0] & 128) {
+        rBytes = new Uint8Array([0, ...rBytes]);
+    }
+    if (sBytes[0] & 128) {
+        sBytes = new Uint8Array([0, ...sBytes]);
+    }
+
+    // compute the length of the Sequence data
+    const seqLen = 2 /*integer header*/ + rBytes.length + 2 /*integer header*/ + sBytes.length;
+
+    // create a single byte array as a DER encoded Sequence of two Integers
+    const der = new Uint8Array([
+        0x30, // Sequence type
+        seqLen, // Length of the Sequence data
+        0x02, // Integer type
+        rBytes.length, // Integer data length
+        ...rBytes, // Integer data
+        0x02, // Integer type
+        sBytes.length, // Integer data length
+        ...sBytes // Integer data
+    ]);
+
+    return der;
+}
+
+
+function jwkToPublicPEM(jwk: JWK): string {
+
+    //  1.2.840.10045.2.1 
+    const ecPublicOid = [0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01];
+
+    // 1.2.840.10045.3.1.7
+    const p256Oid = [0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07];
+
+    const x = convert.base64ToBytes(jwk.x);
+    const y = convert.base64ToBytes(jwk.y);
+
+    const innerSeq = new Uint8Array([
+        0x30, // Sequence type
+        ecPublicOid.length + p256Oid.length,
+        ...ecPublicOid,
+        ...p256Oid
+    ]);
+
+    const bitString = new Uint8Array([
+        0x03, // Bitstring type
+        1 + 1 + x.length + y.length,
+        0, // always 0
+        4, // always 4
+        ...x,
+        ...y
+    ]);
+
+    const der = new Uint8Array([
+        0x30, // Sequence type
+        innerSeq.length + bitString.length,
+        ...innerSeq,
+        ...bitString
+    ]);
+
+    const b64 = convert.bytesToBase64(der);
+
+    const lines = b64.match(/(.{1,64})/g) as Array<string>;
+    lines.unshift('-----BEGIN PUBLIC KEY-----');
+    lines.push('-----END PUBLIC KEY-----');
+
+    return lines.join('\n');
+}
+
+
+function jwkToPrivatePEM(jwk: JWK): string {
+
+    //  1.2.840.10045.2.1 
+    const ecPublicOid = [0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01];
+
+    // 1.2.840.10045.3.1.7
+    const p256Oid = [0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07];
+
+    const x = convert.base64ToBytes(jwk.x);
+    const y = convert.base64ToBytes(jwk.y);
+    const d = convert.base64ToBytes(jwk.d as string);
+
+    const oidSeq = new Uint8Array([
+        0x30, // Sequence type
+        ecPublicOid.length + p256Oid.length,
+        ...ecPublicOid,
+        ...p256Oid
+    ]);
+
+    const bitString = new Uint8Array([
+        0x03, // Bitstring type
+        1 + 1 + x.length + y.length,
+        0, // always 0
+        4, // always 4
+        ...x,
+        ...y
+    ]);
+
+    const keySeq = new Uint8Array([
+        0x30, // Sequence type
+        3 + (d.length + 2) + (p256Oid.length + 2) + (bitString.length + 2),
+
+        0x02,  // Integer 1
+        1,
+        1,
+
+        0x04, // OctetString w/ private key
+        d.length,
+        ...d,
+
+        0xA0, // Custom 0 w/ oid
+        p256Oid.length,
+        ...p256Oid,
+
+        0xA1, // Custom 1 w/ public key Bitstring
+        bitString.length,
+        ...bitString
+    ]);
+
+    let derLen = [3 + oidSeq.length + (keySeq.length + 2)];
+    if (derLen[0] > 128) {
+        derLen = [129, derLen[0]];
+    }
+
+    const der = new Uint8Array([
+        0x30, // Sequence type
+        ...derLen,
+
+        0x02, // Integer 0
+        1,
+        0,
+
+        ...oidSeq, // Sequence with oids
+
+        0x04, // Octetstring w/key Sequnce
+        keySeq.length,
+        ...keySeq
+
+    ]);
+
+    const b64 = convert.bytesToBase64(der);
+
+    const lines = b64.match(/(.{1,64})/g) as Array<string>;
+    lines.unshift('-----BEGIN PRIVATE KEY-----');
+    lines.push('-----END PRIVATE KEY-----');
+
+    return lines.join('\n');
+}
+
+
+function hash(data: BufferSource): Promise<string> {
+    return (subtle ? subtleHash : nodeHash)(data).catch(err => {
+        throw err
+    });
+}
+
+
+function verify(publicKey: JWK, signature: Uint8Array, data: Uint8Array): Promise<boolean> {
+    return (subtle ? subtleVerify : nodeVerify)(publicKey, signature, data).catch(err => {
+        return false;
+    });
+}
+
+
+function sign(privateKey: JWK, data: Uint8Array): Promise<ArrayBuffer> {
+    return (subtle ? subtleSign : nodeSign)(privateKey, data).catch(err => {
+        throw err;
+    });
+}
+
+
+export { hash, sign, verify }

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,6 +97,4 @@ const low = {
     card : card
 }
 
-export default { verify, Context, LogLevel, ErrorCode, directory, low };
-
 export { verify, Context, LogLevel, ErrorCode, directory, low };

--- a/src/key.ts
+++ b/src/key.ts
@@ -3,7 +3,7 @@
 
 import Context from "./context.js";
 import convert from "./convert.js";
-import subtle from "./crypto.js";
+import {hash} from './crypto.js';
 import { ErrorCode } from "./error.js";
 import { JWK, Base64Url } from "./types.js";
 import utils from "./utils.js";
@@ -113,16 +113,11 @@ async function computeKid(key: JWK): Promise<Base64Url> {
 
     const keyBytes = convert.textToBytes(JSON.stringify(pKey));
 
-    return subtle.digest({ name: "SHA-256", }, keyBytes)
-        .then((arrayBuffer: ArrayBuffer) => {
-            const uint8 = new Uint8Array(arrayBuffer);
-            const hash = convert.bytesToBase64(uint8, true);
-            return hash;
-        })
-        .catch((error: Error) => {
-            throw error;
-        });
+    const hashResult = await hash(keyBytes).catch(err => {
+        throw err;
+    });
 
+    return hashResult;
 }
 
 const validate = {

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -6,7 +6,7 @@ import signature_verifier from "./signature.js";
 import { Options, JWSCompact, QRUrl, ShcNumeric, JWSFlat } from "./types.js";
 import { low } from "./index.js";
 import artifactDecoder from './decode.js';
-import card from './card.js';
+
 
 /**
  * Decodes and validates an encoded __SMART Health Card__:

--- a/test/signature.test.ts
+++ b/test/signature.test.ts
@@ -9,6 +9,7 @@ import { checkErrors } from "./utils.js";
 import utils from '../src/utils.js';
 import { Directory, Issuer, IssuerInfo, JWK, JWSHeader, JWSPayload, Options } from '../src/types.js';
 import {data} from './constants.js';
+import payload from '../src/jws.payload';
 
 
 const EC = ErrorCode;
@@ -122,4 +123,23 @@ test('signature-verify-valid-with-non-matching-keys', async () => {
     key.kid = key.x;
     await signature.verify(context);
     checkErrors(context, ErrorCode.DIRECTORY_KEY_NOT_FOUND);
+});
+
+
+test('signature-sign-valid', async () => {
+    const pubKey = {...data.privateKey};
+    delete (pubKey as Partial<JWK>).d;
+    const context = new Context({ privateKey: data.privateKey, keys: [pubKey] });
+    
+    // get a payload object
+    context.flat.payload = data.flat.payload;
+    payload.decode(context);
+
+    // sign
+    await signature.sign(context);
+    checkErrors(context);
+
+    // verify
+    await signature.verify(context);
+    checkErrors(context, [[],[ErrorCode.KEYS_ONLY_MATCH]]);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
     "target": "ES2020"
   },
   "include": [
-    "src/*.ts"
+    "src"
   ]
 }


### PR DESCRIPTION
Updated crypto for Node and browser use:
- When running in Node >= 15, Node's web crypto api will be used for signature verification.
- When running in Node <= 14, Node's crypto lib will be used (web crypto is not available)
- When running in Browser, the built-in web crypto api will be used.
- When running in a browser without the web crypto api, a web crypto polyfill will be used.