### PR TITLE
Catch failed req()

### DIFF
--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -33,7 +33,10 @@ function selectSubtle() {
     // Using commonjs type imports to avoid the static imports of esm and the errors it creates when the import is not present
     // Require may or may not exist, so we create a do-nothing function if it's not found.
     const req = (typeof require === 'function') ? require : () => { };
-    const nodeCrypto = req('crypto');
+    let nodeCrypto;
+    try {
+        nodeCrypto = req('crypto');
+    } catch { }
     const browserCrypto = typeof crypto === 'undefined' ? undefined : crypto;
 
 


### PR DESCRIPTION
This isn't a problem with the code here, but in some bundler contexts (I'm seeing this with parcel), generated output looks like:
![image](https://user-images.githubusercontent.com/313089/162336658-42a6cb22-b82b-456b-8345-309cb26b0f99.png)

... i.e., `req` may wind up undefined because the bundler helpfully determined at build time that `resolve` exists, even though at runtime it doesn't.

A try/catch is a bit of an ad-hoc fix but it's doing the trick in this instance.