### PR TITLE
omit issuer that fail validation from Directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGE LOG
 
+## v1.1.1
+- Added option to omit malformed issuers from a Directory instead of failing the entire Directory (this is now the default)
+
 ## v1.1.0
 - Add revocation support
 - Add Directory class

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-health-card-decoder",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "description": "API for decoding a QR encoded SMART Health Card",
   "main": "esm/index.js",
   "types": "esm/index.d.ts",

--- a/src/directory.ts
+++ b/src/directory.ts
@@ -268,7 +268,7 @@ async function createFromUrl(url: string, context: Context): Promise<[IDirectory
         return [undefDirectory, context];
     }
 
-    if (!(await validate(downloaded as IDirectory, context))) {
+    if ( (await validate(downloaded as IDirectory, context)) === false && context.options.validation?.directory?.ommitBadIssuers === false ) {
         return [undefDirectory, context];
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,7 +133,8 @@ export interface DirectoryOptions {
         filterBadKeys?: boolean
     },
     directory?: {
-        allowDuplicates?: boolean
+        allowDuplicates?: boolean,
+        ommitBadIssuers?: boolean
     }
 }
 


### PR DESCRIPTION
Currently when a Directory had issuers that failed validation, the entire Directory would be considered invalid.
This change omits only the invalid issuers and allows the Directory to be used.
A new setting has been added to allow this behavior to be turned on and off.
The default now is to omit the invalid issuers.

updated version to 1.1.1