### PR TITLE
Include optional text in vaccine coding

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -56,7 +56,8 @@ export interface ImmunizationResource extends Resource {
         coding: {
             system: string,
             code: string
-        }[]
+        }[],
+        text?: string
     },
     patient: {
         reference: string


### PR DESCRIPTION
Hello - newcomer here! 👋 

## The Context

I'm working on building Smart Health Links that contain a patient's immunization history, and am using the Commons Project's [SHC Web Reader](https://github.com/the-commons-project/shc-web-reader) to view the links. I use this library to build the SHCards in the Links, and the viewer uses this lib to verify SHCards in the links.

I'd like to add a bit of readability to the immunization resources themselves. Right now, I include the CVX code of the vaccine in the bundle, but I would also like to include the human readable name of the vaccine. This will  prevent the SHC Web Reader from having to understand the codes from the various coding systems to find vaccine names.

It seems the "text" property of the vaccine code within the immunization resource might be the right place for this? If not, I'm all ears.

## The Change

Extends the existing ImmunizationResource type's vaccineCode to include the optional "text" property. I believe this is in line with the https://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig/StructureDefinition-shc-vaccination-dm.html spec which indicates vaccineCode is a
http://hl7.org/fhir/R4/datatypes.html#CodeableConcept